### PR TITLE
Don't allow users to access profile before email is verified

### DIFF
--- a/src/components/pages/register/registerPending.js
+++ b/src/components/pages/register/registerPending.js
@@ -4,11 +4,6 @@ import { Button } from 'reactstrap';
 import { replace } from 'react-router-redux';
 
 class RegisterPending extends React.Component {
-    componentWillMount() {
-        if (!this.props.sentEmail) {
-            this.props.redirectHome();
-        }
-    }
     render() {
         return(
             <div className="container-pending">

--- a/src/components/pages/register/registerPending.js
+++ b/src/components/pages/register/registerPending.js
@@ -11,10 +11,12 @@ class RegisterPending extends React.Component {
                     A verification link has been sent to <strong>{this.props.email}</strong>,
                     please click on the link in your mailbox to continue the registration
                 </div>
+                {/*
                 <div className="pending-registration-btns">
                     <div className="pending-btn"><Button color="primary" block>Back</Button></div>
                     <div className="pending-btn"><Button color="primary" block>Resend Link</Button></div>
                 </div>
+                */}
             </div>
         )
     }

--- a/src/container/home.js
+++ b/src/container/home.js
@@ -6,13 +6,38 @@ import { Actions } from '../reducer';
 import Home from '../components/pages/home';
 
 class HomeContainer extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            fetching: false
+        }
+    }
+
     componentDidMount() {
         if (this.props.loggedIn) {
+            this.setState({
+                fetching: true
+            });
+            this.props.fetchProfile();
+        }
+    }
+
+    componentWillReceiveProps(nextProps) {
+        this.setState({
+            fetching: false
+        });
+
+        if (nextProps.verified) {
             this.props.redirectToProfile();
         }
     }
 
     render() {
+        if (this.state.fetching) {
+            return <div></div>;
+        }
+
         return(
             <Home 
                 signUp={this.props.signUp}
@@ -23,8 +48,11 @@ class HomeContainer extends React.Component {
 
 const mapStateToProps = state => {
     const Login = state.Login;
+    const Profile = state.Profile;
+
     return {
-        loggedIn: Login.get('authenticated')
+        loggedIn: Login.get('authenticated'),
+        verified: Profile.getIn(['user', 'verified']),
     }
 }
 

--- a/src/container/login.js
+++ b/src/container/login.js
@@ -13,7 +13,7 @@ class LoginContainer extends React.Component {
     }
 
     componentWillReceiveProps(nextProps){
-        if (nextProps.loginSuccess && !nextProps.error){
+        if (nextProps.loginSuccess && nextProps.profileFetched && !nextProps.error){
             nextProps.redirect()
         };
     }
@@ -21,8 +21,8 @@ class LoginContainer extends React.Component {
     render() {
         return(
             <Login
-                login={this.props.login} // what is this for?
-                loginSuccess={this.props.loginSuccess} // why do you need this here?
+                login={this.props.login}
+                loginSuccess={this.props.loginSuccess}
             />
         ) 
     }
@@ -30,10 +30,12 @@ class LoginContainer extends React.Component {
 
 const mapStateToProps = state => {
     const LoginState = state.Login;
+    const Profile = state.Profile;
+
     return {
         loading: LoginState.get('loading'),
         loginSuccess: LoginState.get('authenticated'),
-        redirectPath: LoginState.get('redirect'),
+        profileFetched: !!Profile.getIn(['user', 'id']),
         error: LoginState.get('error')
     }
 };
@@ -44,11 +46,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
         	dispatch(Actions.loginActions.login(email, password));
         },
         redirect: () => {
-            if (ownProps.redirectPath) {
-                dispatch(replace(redirectPath));
-            } else {
-                dispatch(replace("/profile"));      
-            }
+            dispatch(replace("/profile"));      
         }
     };
 };

--- a/src/container/requireAuthentication.js
+++ b/src/container/requireAuthentication.js
@@ -14,9 +14,12 @@ export default function(ComposedComponent) {
             if (!this.props.isProfileFetched) {
                 this.props.fetchProfile();
             }
+            if (!this.props.isProfileVerified) {
+                return this.props.redirectToPending();
+            }
         }
 
-        componentWillUpdate(nextProps) {
+        componentWillReceiveProps(nextProps) {
             if (!nextProps.isLoggedIn) {
                 this.props.login();
             }
@@ -35,7 +38,7 @@ export default function(ComposedComponent) {
         return {
             isLoggedIn: Login.get('authenticated'),
             isProfileFetched: !!Profile.getIn(['user', 'id']),
-            path: path
+            isProfileVerified: Profile.getIn(['user', 'verified']),
         }
     }
 
@@ -46,7 +49,10 @@ export default function(ComposedComponent) {
             },
             fetchProfile: () => {
                 dispatch(Actions.profileActions.fetchProfile());
-            }
+            },
+            redirectToPending: () => {
+                dispatch(replace("/register/pending"));
+            },
         };
     }
 

--- a/src/main.js
+++ b/src/main.js
@@ -42,9 +42,9 @@ class App extends React.Component {
                             <Route exact path="/login" component={LoginContainer}/>
                             <Route exact path="/register" component={RegisterContainer}/>
                             <Route path="/register/pending" component={RegisterPendingContainer} />
+                            <Route path="/completeRegistration" component={CompleteRegistrationContainer} />
+                            <Route path="/verify" component={VerifyUserContainer} />
 
-                            <Route path="/completeRegistration" component={Authentication(CompleteRegistrationContainer)} />
-                            <Route path="/verify" component={Authentication(VerifyUserContainer)} />
                             <Route exact path="/profile" component={Authentication(ProfileContainer)} />
                             <Route exact path="/search" component={Authentication(SearchContainer)} />
                             <Route exact path="/requests" component={Authentication(RequestsContainer)}/>

--- a/src/reducer/login.js
+++ b/src/reducer/login.js
@@ -81,7 +81,9 @@ const login = (email, password) => {
                 throw new Error("Error login");
             } else {
                 Storage.set("token", data.access_token)
-
+                
+                // get their profile
+                dispatch(fetchProfile());
                 dispatch(loginSuccess());
             }
         } catch (error) {


### PR DESCRIPTION
## Don't allow users to login before they have their email verified

### Please test:
1) register a new user
2) when you come to the /register/pending page that says "an email has been sent to ..." change the url to /profile and make sure that you can't get in
3) start from the landing page and make sure that you can't get into the profile
4) verify the user the normal way (grab the link from the email and change 8000 to 8080 and continue with completing the registration) and make sure that this works