### PR TITLE
Don't require token to confirm verification code

### DIFF
--- a/src/container/login.js
+++ b/src/container/login.js
@@ -2,19 +2,22 @@ import React from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { push, replace, goBack } from 'react-router-redux';
+import { parse } from 'qs';
+
 import { Actions } from '../reducer';
 import Login from '../components/pages/login';
 
 class LoginContainer extends React.Component {
     componentWillMount() {
         if (this.props.loginSuccess && !this.props.error){
-            this.props.redirect()
+            this.props.redirect();
         };
     }
 
     componentWillReceiveProps(nextProps){
         if (nextProps.loginSuccess && nextProps.profileFetched && !nextProps.error){
-            nextProps.redirect()
+            const parsed = parse(nextProps.location.search.substr(1));
+            return this.props.redirect(parsed.redirect);
         };
     }
 
@@ -45,8 +48,12 @@ const mapDispatchToProps = (dispatch, ownProps) => {
         login: (email, password) => {
         	dispatch(Actions.loginActions.login(email, password));
         },
-        redirect: () => {
-            dispatch(replace("/profile"));      
+        redirect: (path) => {
+            if (!path) {
+                dispatch(replace("/profile"));
+            } else {
+                dispatch(replace(path));
+            }
         }
     };
 };

--- a/src/reducer/register.js
+++ b/src/reducer/register.js
@@ -1,5 +1,6 @@
 import Immutable from 'immutable';
 import { addNotification as notify } from 'reapop';
+import { replace } from 'react-router-redux';
 
 import { setProfile } from './profile';
 import { login } from './login';
@@ -87,15 +88,20 @@ const sendVerificationLink = (email, password) => {
 }
 
 const confirmCode = (verification_code) => {
-    return async dispatch => {
+    return async (dispatch, getState) => {
         try {
+            if (!Storage.get("token")) {
+                const state = getState();
+                const redirect = state.router.location.pathname + state.router.location.search;
+                return dispatch(replace(`/login?redirect=${redirect}`));
+            }
+
             dispatch({type: VERIFY_CODE_START});
 
             const response = await fetch(Config.API_URL + '/verify/', {
                 method: 'POST',
                 headers: new Headers({
                     "Content-Type": "application/json",
-                    Authorization: `Bearer ${Storage.get("token")}`
                 }),
                 body: JSON.stringify({
                     verification_code


### PR DESCRIPTION
## Description
In order to allow people to complete the registration on their phone or another device other than the one that they initially put their email and password in, we allow the confirmation code to be sent to the backend without the auth token
* If the user is already logged in, then the behavior remains the same
* if the user is not logged in, we redirect them to login page first, then allow them to complete the registration

## Make sure
- [x] Tested and Working

## Test Plan

What happens when they clink on the verification link on the same computer they used to register
![loggedin](https://user-images.githubusercontent.com/12592200/36877851-1de611c2-1d71-11e8-8a64-37f061829da8.gif)

What happens when they click on the link on a different computer
![notloggedin](https://user-images.githubusercontent.com/12592200/36877868-3039e0ba-1d71-11e8-95c6-34657a28c899.gif)
