### PR TITLE
Google Analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8408,6 +8408,15 @@
         "uuid4": "^1.0.0"
       }
     },
+    "react-ga": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-2.5.0.tgz",
+      "integrity": "sha512-pnkoXO9YOHOC9+0qCD3HhmYJrKvhU0iEvNpS2IKRHb9BBrpwCjk23/gaClnj4lewwIKsD2PYZ74YpHiNQ4WRNg==",
+      "requires": {
+        "prop-types": "15.6.0",
+        "react": "15.6.2"
+      }
+    },
     "react-redux": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react": "^15.5.3",
     "react-dom": "^15.5.3",
     "react-file-reader": "^1.1.3",
+    "react-ga": "^2.5.0",
     "react-redux": "^5.0.4",
     "react-router-dom": "^4.0.0",
     "react-router-redux": "^5.0.0-alpha.4",

--- a/src/container/analytics.js
+++ b/src/container/analytics.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import GoogleAnalytics from 'react-ga';
+
+GoogleAnalytics.initialize('UA-118469639-1', {
+        debug: true
+    }
+);
+
+const withTracker = (WrappedComponent, options = {}) => {
+    const trackPage = page => {
+            GoogleAnalytics.set({
+            page,
+            ...options,
+        });
+        GoogleAnalytics.pageview(page);
+    };
+
+    const HOC = class extends React.Component {
+        componentDidMount() {
+            const page = this.props.location.pathname;
+            trackPage(page);
+        }
+
+        componentWillReceiveProps(nextProps) {
+            const currentPage = this.props.location.pathname;
+            const nextPage = nextProps.location.pathname;
+
+            if (currentPage !== nextPage) {
+                trackPage(nextPage);
+            }
+        }
+
+        render() {
+            return <WrappedComponent {...this.props} />;
+        }
+    };
+
+    return HOC;
+};
+
+export default withTracker;

--- a/src/container/analytics.js
+++ b/src/container/analytics.js
@@ -1,10 +1,7 @@
 import React from 'react';
 import GoogleAnalytics from 'react-ga';
 
-GoogleAnalytics.initialize('UA-118469639-1', {
-        debug: true
-    }
-);
+GoogleAnalytics.initialize('UA-118469639-1');
 
 const withTracker = (WrappedComponent, options = {}) => {
     const trackPage = page => {

--- a/src/main.js
+++ b/src/main.js
@@ -22,9 +22,14 @@ import LoginContainer from './container/login';
 import MessagesContainer from 'container/messages';
 import Authentication from './container/requireAuthentication';
 import RegisterPendingContainer from './components/pages/register/registerPending';
+import ReactGA from 'react-ga';
 
 import 'bootstrap/dist/css/bootstrap.css';
 import './main.scss';
+
+// google analytics
+ReactGA.initialize('UA-000000-01');
+ReactGA.pageview(window.location.pathname + window.location.search);
 
 if (module.hot) {
     module.hot.accept();

--- a/src/main.js
+++ b/src/main.js
@@ -27,41 +27,7 @@ import 'bootstrap/dist/css/bootstrap.css';
 import './main.scss';
 
 // google analytics
-import GoogleAnalytics from 'react-ga';
-
-GoogleAnalytics.initialize('UA-118469639-1');
-
-const withTracker = (WrappedComponent, options = {}) => {
-  const trackPage = page => {
-    GoogleAnalytics.set({
-      page,
-      ...options,
-    });
-    GoogleAnalytics.pageview(page);
-  };
-
-  const HOC = class extends React.Component {
-    componentDidMount() {
-      const page = this.props.location.pathname;
-      trackPage(page);
-    }
-
-    componentWillReceiveProps(nextProps) {
-      const currentPage = this.props.location.pathname;
-      const nextPage = nextProps.location.pathname;
-
-      if (currentPage !== nextPage) {
-        trackPage(nextPage);
-      }
-    }
-
-    render() {
-      return <WrappedComponent {...this.props} />;
-    }
-  };
-
-  return HOC;
-};
+import withTracker from './container/analytics.js';
 
 class PageTracker extends React.Component {
     render() { return null; }

--- a/src/main.js
+++ b/src/main.js
@@ -40,7 +40,7 @@ const withTracker = (WrappedComponent, options = {}) => {
     GoogleAnalytics.pageview(page);
   };
 
-  const HOC = class extends Component {
+  const HOC = class extends React.Component {
     componentDidMount() {
       const page = this.props.location.pathname;
       trackPage(page);
@@ -62,6 +62,10 @@ const withTracker = (WrappedComponent, options = {}) => {
 
   return HOC;
 };
+
+class PageTracker extends React.Component {
+    render() { return null; }
+}
 
 if (module.hot) {
     module.hot.accept();
@@ -89,6 +93,7 @@ class App extends React.Component {
                             <Route exact path="/mentors/:mentorId" component={Authentication(MentorDetailContainer)} />
                             <Redirect to="/"/>
                         </Switch>
+                        <Route path="/" component={withTracker(PageTracker)} />
                     </div>
                 </ConnectedRouter>
             </Provider>
@@ -96,9 +101,7 @@ class App extends React.Component {
     }
 }
 
-const TrackedApp = withTracker(App);
-
 render(
-    <TrackedApp />,
+    <App />,
     document.getElementById('mount')
 );

--- a/src/main.js
+++ b/src/main.js
@@ -22,14 +22,46 @@ import LoginContainer from './container/login';
 import MessagesContainer from 'container/messages';
 import Authentication from './container/requireAuthentication';
 import RegisterPendingContainer from './components/pages/register/registerPending';
-import ReactGA from 'react-ga';
 
 import 'bootstrap/dist/css/bootstrap.css';
 import './main.scss';
 
 // google analytics
-ReactGA.initialize('UA-000000-01');
-ReactGA.pageview(window.location.pathname + window.location.search);
+import GoogleAnalytics from 'react-ga';
+
+GoogleAnalytics.initialize('UA-118469639-1');
+
+const withTracker = (WrappedComponent, options = {}) => {
+  const trackPage = page => {
+    GoogleAnalytics.set({
+      page,
+      ...options,
+    });
+    GoogleAnalytics.pageview(page);
+  };
+
+  const HOC = class extends Component {
+    componentDidMount() {
+      const page = this.props.location.pathname;
+      trackPage(page);
+    }
+
+    componentWillReceiveProps(nextProps) {
+      const currentPage = this.props.location.pathname;
+      const nextPage = nextProps.location.pathname;
+
+      if (currentPage !== nextPage) {
+        trackPage(nextPage);
+      }
+    }
+
+    render() {
+      return <WrappedComponent {...this.props} />;
+    }
+  };
+
+  return HOC;
+};
 
 if (module.hot) {
     module.hot.accept();
@@ -64,8 +96,9 @@ class App extends React.Component {
     }
 }
 
+const TrackedApp = withTracker(App);
 
 render(
-    <App/>,
+    <TrackedApp />,
     document.getElementById('mount')
 );


### PR DESCRIPTION
- set up google analytics with the BQuest gmail account
- added react-ga to main.js
- should be able to track different pages/URLs that react router switches to

- [ ] need to check if it works for pages on the actual site since it's configured to track views on the Bquest website