### PR TITLE
fixed overlapping between search results and footer on search/index.js

### DIFF
--- a/src/components/pages/search/index.js
+++ b/src/components/pages/search/index.js
@@ -22,7 +22,9 @@ class Search extends React.Component {
                     count={this.props.count}
                     _internal={this.props._internal} 
                 />
-                <Footer />
+                <div className="results-footer">
+                    <Footer />
+                </div>
             </div>
         );
     }

--- a/src/components/pages/search/style.scss
+++ b/src/components/pages/search/style.scss
@@ -71,6 +71,10 @@
     }
   }
 
+  .results-footer {
+    margin-top: 80px;
+  }
+
   .search--search-container {
     display: flex;
     height: 150px;


### PR DESCRIPTION
## Description
<!--Added margin-top property to a div wrapping around <Footer /> in components/pages/search/index.js to fix overlapping between search results and footer

<img width="703" alt="screen shot 2019-02-09 at 6 30 39 pm" src="https://user-images.githubusercontent.com/21168236/52528673-de6f5480-2c98-11e9-9025-569f53cdbe11.png">
-->

## Make sure
- [x] Tested and Working

## Test Plan
<!-- Add pictures or GIF to show that it's working -->
